### PR TITLE
sync-from-sourceforge.yml: ignore branches missing on SF side

### DIFF
--- a/.github/workflows/sync-from-sourceforge.yml
+++ b/.github/workflows/sync-from-sourceforge.yml
@@ -47,7 +47,6 @@ jobs:
               git checkout "$branch"
               
               # Attempt a fast-forward merge.
-              # The '|| true' ensures the script continues even if the merge fails.
               if ! git merge --ff-only "sourceforge/$branch"; then
                 # If the merge fails, it means it was not a fast-forward.
                 # We print a warning and do not perform a merge or rebase.

--- a/.github/workflows/sync-from-sourceforge.yml
+++ b/.github/workflows/sync-from-sourceforge.yml
@@ -38,23 +38,30 @@ jobs:
 
           # Loop through each local branch.
           for branch in $(git branch --format='%(refname:short)'); do
-            echo "--------------------------------------------------------"
-            echo "Processing branch: $branch"
-            
-            # Switch to the branch.
-            git checkout "$branch"
-            
-            # Attempt a fast-forward merge.
-            # The '|| true' ensures the script continues even if the merge fails.
-            if ! git merge --ff-only "sourceforge/$branch"; then
-              # If the merge fails, it means it was not a fast-forward.
-              # We print a warning and do not perform a merge or rebase.
-              echo "::warning file=$branch::Could not fast-forward merge branch '$branch'. Please merge or rebase manually."
+            # Check if the corresponding branch exists on the 'sourceforge' remote.
+            if git show-ref --quiet --verify "refs/remotes/sourceforge/$branch"; then
+              echo "--------------------------------------------------------"
+              echo "Processing branch: $branch"
+              
+              # Switch to the branch.
+              git checkout "$branch"
+              
+              # Attempt a fast-forward merge.
+              # The '|| true' ensures the script continues even if the merge fails.
+              if ! git merge --ff-only "sourceforge/$branch"; then
+                # If the merge fails, it means it was not a fast-forward.
+                # We print a warning and do not perform a merge or rebase.
+                echo "::warning file=$branch::Could not fast-forward merge branch '$branch'. Please merge or rebase manually."
+              else
+                # If the merge succeeds, we push the changes back to GitHub.
+                echo "Fast-forward merge successful on '$branch'."
+                git push origin "$branch"
+              fi
+              
+              echo "--------------------------------------------------------"
             else
-              # If the merge succeeds, we push the changes back to GitHub.
-              echo "Fast-forward merge successful on '$branch'."
-              git push origin "$branch"
+              echo "--------------------------------------------------------"
+              echo "Skipping branch '$branch' as it does not exist on the 'sourceforge' remote."
+              echo "--------------------------------------------------------"
             fi
-            
-            echo "--------------------------------------------------------"
           done

--- a/.github/workflows/sync-from-sourceforge.yml
+++ b/.github/workflows/sync-from-sourceforge.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
           # This gives the workflow permissions to push changes back to the repository.
           # The GITHUB_TOKEN is a temporary token with push permissions.
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
 
       # Step 2: Add the remote SourceForge repository as 'sourceforge'.
       # The '--fetch' flag immediately fetches the remote's refs.

--- a/.github/workflows/sync-from-sourceforge.yml
+++ b/.github/workflows/sync-from-sourceforge.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   fast-forward-sync:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
     
     steps:
       # Step 1: Checkout the current repository code.
@@ -22,7 +25,7 @@ jobs:
           fetch-depth: 0
           # This gives the workflow permissions to push changes back to the repository.
           # The GITHUB_TOKEN is a temporary token with push permissions.
-          token: ${{ secrets.PDOS_PROJECT_WRITE }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       # Step 2: Add the remote SourceForge repository as 'sourceforge'.
       # The '--fetch' flag immediately fetches the remote's refs.


### PR DESCRIPTION
- Don't even try to fast-forward merge local branch if it doesn't exist on SourceForge side
- Remove incorrect comment (explaining use of `|| true` when it wasn't actually being used)
- Test using GITHUB_TOKEN with write permissions instead of PAT – test passed, GITHUB_TOKEN is easier to manage than manually maintained PAT